### PR TITLE
Typo fix in renewal function return value

### DIFF
--- a/modules/registrars/stregistry/stregistry.php
+++ b/modules/registrars/stregistry/stregistry.php
@@ -360,7 +360,7 @@ function stregistry_RenewDomain($params) {
 		return __errorArray(ResponseHelper::fromJSON($json)->message);
 	}
 	
-	return $values;
+	return 'success';
 }
 
 /**


### PR DESCRIPTION
Fix renewal function so it return 'success' string instead of null (undefined variable)