### PR TITLE
Add required parameter to domain transfer query call. …

### DIFF
--- a/modules/registrars/stregistry/stregistry.php
+++ b/modules/registrars/stregistry/stregistry.php
@@ -723,7 +723,7 @@ function stregistry_TransferSync($params)
 		return __errorArray($status);
 	}
 	// query transfer status
-	$json = STRegistry::Domains()->transferQuery($params['domain']);
+	$json = STRegistry::Domains()->transferQuery($params['domain'], null);
 	if (!ResponseHelper::isSuccess($json)) {
 		return __errorArray(ResponseHelper::fromJSON($json)->message);
 	}


### PR DESCRIPTION
Null is allowed since both loosing and gaining registrars could fetch transfer status without auth code